### PR TITLE
Use final_internal_class with annotation_exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,47 +8,63 @@ Pint strict preset is an insanely defensive coding style preset for those who de
 
 ```json
 {
-    "preset": "laravel",
-    "rules": {
-        "array_push": true,
-        "backtick_to_shell_exec": true,
-        "declare_strict_types": true,
-        "final_class": true,
-        "fully_qualified_strict_types": true,
-        "global_namespace_import": {
-            "import_classes": true,
-            "import_constants": true,
-            "import_functions": true
-        },
-        "ordered_class_elements": {
-            "order": [
-                "use_trait",
-                "case",
-                "constant",
-                "constant_public",
-                "constant_protected",
-                "constant_private",
-                "property_public",
-                "property_protected",
-                "property_private",
-                "construct",
-                "destruct",
-                "magic",
-                "phpunit",
-                "method_abstract",
-                "method_public_static",
-                "method_public",
-                "method_protected_static",
-                "method_protected",
-                "method_private_static",
-                "method_private"
-            ],
-            "sort_algorithm": "none"
-        },
-        "ordered_interfaces": true,
-        "ordered_traits": true,
-        "protected_to_private": true,
-        "strict_comparison": true
-    }
+  "preset": "laravel",
+  "rules": {
+    "array_push": true,
+    "backtick_to_shell_exec": true,
+    "date_time_immutable": true,
+    "declare_strict_types": true,
+    "lowercase_keywords": true,
+    "lowercase_static_reference": true,
+    "final_internal_class": {
+      "annotation_include": [],
+      "annotation_exclude": ["internal"]
+    },
+    "final_public_method_for_abstract_class": true,
+    "fully_qualified_strict_types": true,
+    "global_namespace_import": {
+      "import_classes": true,
+      "import_constants": true,
+      "import_functions": true
+    },
+    "mb_str_functions": true,
+    "modernize_types_casting": true,
+    "new_with_parentheses": false,
+    "no_superfluous_elseif": true,
+    "no_useless_else": true,
+    "no_multiple_statements_per_line": true,
+    "ordered_class_elements": {
+      "order": [
+        "use_trait",
+        "case",
+        "constant",
+        "constant_public",
+        "constant_protected",
+        "constant_private",
+        "property_public",
+        "property_protected",
+        "property_private",
+        "construct",
+        "destruct",
+        "magic",
+        "phpunit",
+        "method_abstract",
+        "method_public_static",
+        "method_public",
+        "method_protected_static",
+        "method_protected",
+        "method_private_static",
+        "method_private"
+      ],
+      "sort_algorithm": "none"
+    },
+    "ordered_interfaces": true,
+    "ordered_traits": true,
+    "protected_to_private": true,
+    "self_accessor": true,
+    "self_static_accessor": true,
+    "strict_comparison": true,
+    "visibility_required": true
+  }
 }
 ```


### PR DESCRIPTION
Removes `final_class` and uses instead

```json
 "final_internal_class": {
      "annotation_include": [],
      "annotation_exclude": ["internal"]
    },
```

`final_class` is an alias for `final_internal_class` as explained [here](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/6126#issuecomment-979740530) and in code [here](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/5d62f21bc77a1b94fdf2c8d3a06d51f2a9f2bb9a/src/Fixer/ClassNotation/FinalClassFixer.php#L60).

So using `final_internal_class` with `"annotation_exclude": ["internal"]` will still make all classes final unless we add `@internal`. This is handy if you want to extend classe in your project.

