### PR TITLE
Refactor: Remove redundant rules already covered by Laravel 12 preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Pint strict preset is an insanely defensive coding style preset for those who de
         "backtick_to_shell_exec": true,
         "date_time_immutable": true,
         "declare_strict_types": true,
-        "lowercase_keywords": true,
-        "lowercase_static_reference": true,
         "final_class": true,
         "final_internal_class": true,
         "final_public_method_for_abstract_class": true,
@@ -30,7 +28,6 @@ Pint strict preset is an insanely defensive coding style preset for those who de
         "new_with_parentheses": false,
         "no_superfluous_elseif": true,
         "no_useless_else": true,
-        "no_multiple_statements_per_line": true,
         "ordered_class_elements": {
             "order": [
                 "use_trait",
@@ -56,11 +53,8 @@ Pint strict preset is an insanely defensive coding style preset for those who de
             ],
             "sort_algorithm": "none"
         },
-        "ordered_interfaces": true,
-        "ordered_traits": true,
         "protected_to_private": true,
         "self_accessor": true,
-        "self_static_accessor": true,
         "strict_comparison": true,
         "visibility_required": true
     }


### PR DESCRIPTION
This PR optimizes the Pint configuration by removing rules that are redundant with Laravel 12's base preset.

Summary of Changes

Removed 6 redundant rules that exactly duplicate Laravel 12 preset defaults:

lowercase_keywords: true
lowercase_static_reference: true
no_multiple_statements_per_line: true
ordered_interfaces: true
ordered_traits: true
self_static_accessor: true